### PR TITLE
[FIX] allow pool with a set amount of objects

### DIFF
--- a/pool.js
+++ b/pool.js
@@ -82,7 +82,7 @@ var Pool = function(options) {
   var max = parseInt(options.max, 10);
   var min = parseInt(options.min, 10);
   this.max = Math.max(isNaN(max) ? 1 : max, 1);
-  this.min = Math.min(isNaN(min) ? 0 : min, this.max - 1);
+  this.min = Math.min(isNaN(min) ? 0 : min, this.max);
 
   // Ensure the minimum is created.
   this.ensureMinimum();

--- a/test/generic-pool.test.js
+++ b/test/generic-pool.test.js
@@ -118,7 +118,7 @@ module.exports = {
         });
     },
 
-    'min greater than max sets to max minus one': function(beforeExit) {
+    'min greater than max sets to max': function(beforeExit) {
         var factory = {
             name: "test-limit-defaults3",
             create: function(callback) {
@@ -134,7 +134,7 @@ module.exports = {
 
         beforeExit(function() {
             assert.equal(3, pool.max);
-            assert.equal(2, pool.min);
+            assert.equal(3, pool.min);
         });
     },
 


### PR DESCRIPTION
so `min` and `max` are equal

A possible solution to https://github.com/bookshelf/generic-pool-redux/issues/2
