### PR TITLE
Only reduce count for objects that were actually removed

### DIFF
--- a/pool.js
+++ b/pool.js
@@ -241,10 +241,13 @@ Pool.prototype = {
   // will also be called. This should be called within an acquire()
   // block as an alternative to release().
   destroy: function(obj) {
-    this.count -= 1;
     this.availableObjects = this.availableObjects.filter(function(objWithTimeout) {
-      return (objWithTimeout.obj !== obj);
-    });
+      if (objWithTimeout.obj === obj) {
+        this.count -= 1;
+        return false;
+      }
+      return true;
+    }.bind(this));
     this.destroyHandler(obj);
     this.ensureMinimum();
   },


### PR DESCRIPTION
Robustify the destroy method slightly. This prevents the problem we discussed on IRC where calling destroy with incorrect arguments will screw up the count and leak connections. This patch enables this one:

https://github.com/tgriesser/knex/pull/659

... without this change, the patch above will leak connections badly
